### PR TITLE
Remove quote from lambda for byte compile warning

### DIFF
--- a/mvn.el
+++ b/mvn.el
@@ -452,7 +452,7 @@
                                                  mvn-build-file-name))))
     (message output)
     (if (> (length output) 0)
-        (mapcar '(lambda (x) (replace-regexp-in-string ".*<target.*name=\"\\([^\-][^\"]*\\).*" "\\1" x))
+        (mapcar (lambda (x) (replace-regexp-in-string ".*<target.*name=\"\\([^\-][^\"]*\\).*" "\\1" x))
                 (split-string output "[\n]"))
       nil)))
 


### PR DESCRIPTION
This fixes following byte-compile warning.

```
mvn.el:456:31:Warning: (lambda (x) ...) quoted with ' rather than with #'
```