### PR TITLE
Rename package name to be consistent with file name.

### DIFF
--- a/mvn.el
+++ b/mvn.el
@@ -1,4 +1,4 @@
-;;; maven.el --- helpers for compiling with maven
+;;; mvn.el --- helpers for compiling with maven
 
 ;; Copyright (C) 2013 Andrew Gwozdziewycz <git@apgwoz.com>
 
@@ -520,4 +520,4 @@
 
 (provide 'mvn)
 
-;;; maven.el ends here
+;;; mvn.el ends here


### PR DESCRIPTION
Hi,

Since this package cannot be installed from melpa, I use `quelpa` to install it.
But surprisingly it's installed as package `maven` in `package-alist`.

it should be `mvn` per https://www.gnu.org/software/emacs/manual/html_node/elisp/Simple-Packages.html IIUC:
> The name of the package is the same as the base name of the file, as written on the first line.

So I rename it to `mvn.el` in the header and footer.
